### PR TITLE
feature: App Context Provider

### DIFF
--- a/src/apps/ErpApp.jsx
+++ b/src/apps/ErpApp.jsx
@@ -1,16 +1,37 @@
 import { Layout } from 'antd'
 import { useDispatch, useSelector } from 'react-redux'
+import { settingsAction } from '~/redux/settings/actions'
+import { useLayoutEffect } from 'react'
+import { selectSetting } from '~/redux/settings/selectors'
+
 import useResponsive from '~/hooks/useResponsive'
+import PageLoader from '~/components/PageLoader'
+import Navigation from './Navigation/NavigationContainer'
 
 export default function ErpApp() {
-  const { Content } = Layout
-  const { isMobile} = useResponsive()
+  const { Content, Sider } = Layout
+  const { isMobile } = useResponsive()
 
   const dispatch = useDispatch()
 
-  return (
-    <Layout hasSider>
-      
-    </Layout>
-  )
+  useLayoutEffect(() => {
+    dispatch(settingsAction.list({ entity: 'setting' }))
+  }, [])
+
+  const { isSuccess: settingIsLoaded } = useSelector(selectSetting)
+
+  if (settingIsLoaded) {
+    return (
+      <Layout hasSider>
+        <Navigation />
+        {isMobile ? (
+          <Content style={{ backgroundColor: 'green' }}>Mobile</Content>
+        ) : (
+          <Content style={{ backgroundColor: 'green' }}>PC</Content>
+        )}
+      </Layout>
+    )
+  } else {
+    return <PageLoader />
+  }
 }

--- a/src/apps/IdurarOs.jsx
+++ b/src/apps/IdurarOs.jsx
@@ -2,6 +2,7 @@ import Localization from '~/locale/Localization'
 import { lazy, Suspense } from 'react'
 import { selectAuth } from '~/redux/auth/selectors'
 import { useSelector } from 'react-redux'
+import { AppContextProvider } from '~/context/appContext'
 
 import PageLoader from '~/components/PageLoader'
 import AuthRouter from '~/router/AuthRouter'
@@ -10,9 +11,11 @@ const ErpApp = lazy(() => import('./ErpApp'))
 
 const DefaultApp = () => (
   <Localization>
-    <Suspense fallback={<PageLoader />}>
-      <ErpApp />
-    </Suspense>
+    <AppContextProvider>
+      <Suspense fallback={<PageLoader />}>
+        <ErpApp />
+      </Suspense>
+    </AppContextProvider>
   </Localization>
 )
 

--- a/src/apps/Navigation/NavigationContainer.jsx
+++ b/src/apps/Navigation/NavigationContainer.jsx
@@ -1,12 +1,25 @@
-import { Link, useLocation, useNavigate } from "react-router-dom"
+import { Link, useLocation, useNavigate } from 'react-router-dom'
+import { Layout } from 'antd'
 
-import useResponsive from "~/hooks/useResponsive"
+import useResponsive from '~/hooks/useResponsive'
 
 export default function Navigation() {
-  const { isMobile} = useResponsive()
+  const { isMobile } = useResponsive()
+
+  return isMobile ? <MobileSideBar /> : <Sidebar collapsible={false}/>
 }
 
 function Sidebar({ collapsible, isMobile = false }) {
   let location = useLocation()
+  const { Sider } = Layout
 
+  return (
+    <Sider style={{ backgroundColor: 'white', height: '100vh' }}>Sider</Sider>
+  )
+}
+
+function MobileSideBar() {
+  return (
+    <div>mobileBar</div>
+  )
 }

--- a/src/context/appContext/actions.jsx
+++ b/src/context/appContext/actions.jsx
@@ -1,0 +1,25 @@
+import * as actionTypes from './types'
+
+const contextActions = (dispatch) => {
+  return {
+    navMenu: {
+      open: () => {
+        dispatch({ type: actionTypes.OPEN_NAV_MENU})
+      },
+      close: () => {
+        dispatch({ type: actionTypes.CLOSE_NAV_MENU})
+      },
+      collapse: () => {
+        dispatch({ type: actionTypes.COLLAPSE_NAV_MENU})
+      },
+    },
+    navMenu: {
+      open: (appName) => {
+        dispatch({ type: actionTypes.CHANGE_APP, payload: appName})
+      },
+      default: () => {
+        dispatch({ type: actionTypes.DEFAULT_APP})
+      }
+    }
+  }
+}

--- a/src/context/appContext/index.jsx
+++ b/src/context/appContext/index.jsx
@@ -1,0 +1,26 @@
+import { useMemo, useReducer, createContext, useContext } from 'react'
+import { initialState, contextReducer } from './reducer'
+import contextActions from './actions'
+
+const AppContext = createContext()
+
+function AppContextProvider({ children }) {
+  const [state, dispatch] = useReducer(contextReducer, initialState)
+  const value = useMemo(() => [state, dispatch], [state])
+
+  return <AppContext.Provider value={value}>{children}</AppContext.Provider>
+}
+
+function useAppContext() {
+  const context = useContext(AppContext)
+  if (context === undefined) {
+    throw new Error('useAppContext must be used within an AppContextProvider')
+  }
+
+  const [state, dispatch] = context
+  const appContextActions = contextActions(dispatch)
+
+  return { state, appContextActions}
+}
+
+export { AppContextProvider, useAppContext}

--- a/src/context/appContext/reducer.jsx
+++ b/src/context/appContext/reducer.jsx
@@ -1,0 +1,38 @@
+import * as actionTypes from './types'
+
+export const initialState = {
+  isNavMenuClose: false,
+  currentApp: 'default',
+}
+
+export function contextReducer(state, action) {
+  switch (action.type) {
+    case actionTypes.OPEN_NAV_MENU:
+      return {
+        ...state,
+        isNavMenuClose: false,
+      }
+    case actionTypes.CLOSE_NAV_MENU:
+      return {
+        ...state,
+        isNavMenuClose: true,
+      }
+    case actionTypes.COLLAPSE_NAV_MENU:
+      return {
+        ...state,
+        isNavMenuClose: !state.isNavMenuClose,
+      }
+    case actionTypes.CHANGE_APP:
+      return {
+        ...state,
+        currentApp: action.payload
+      }
+    case actionTypes.DEFAULT_APP: 
+      return {
+        ...state,
+        currentApp: 'default'
+      }
+    default: 
+      throw new Error(`Unhandled action type: ${action.type}`)
+  }
+}

--- a/src/context/appContext/types.jsx
+++ b/src/context/appContext/types.jsx
@@ -1,0 +1,5 @@
+export const OPEN_NAV_MENU = 'OPEN_NAV_MENU'
+export const CLOSE_NAV_MENU = 'CLOSE_NAV_MENU'
+export const COLLAPSE_NAV_MENU = 'COLLAPSE_NAV_MENU'
+export const CHANGE_APP = 'CHANGE_APP'
+export const DEFAULT_APP = 'DEFAULT_APP'

--- a/src/redux/settings/actions.js
+++ b/src/redux/settings/actions.js
@@ -29,7 +29,7 @@ const dispatchSettingsData = (datas) => {
   })
 }
 
-export const settingAction = {
+export const settingsAction = {
   resetState: () => (dispatch) => {
     dispatch({
       type: actionTypes.RESET_STATE,


### PR DESCRIPTION
changes:
- appContext

detail:
- like redux, useReducer allow user to get state from any where, avoid props drilling
- dont support thunk so we have to find another way to implement dispatch
- useMemo help to avoid re calculate unenccessary by react render (recalculate every time render)